### PR TITLE
項目未チェック時、透明の一括ダウンロードボタンが操作できる

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -67,7 +67,9 @@
     const button = document.getElementById(BUTTON_ID);
     if (button) {
       const container = document.getElementById(DOWNLOAD_CONTAINER_ID);
-      container.style.opacity = Object.keys(loadStorageData()).length > 0 ? 1 : 0;
+      const hasData = Object.keys(loadStorageData()).length > 0;
+      container.style.opacity = hasData ? 1 : 0;
+      container.style.visibility = hasData ? "visible" : "hidden" ;
     }
   }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -24,6 +24,7 @@ button#listendltool_download:hover {
   gap: 10px; /* ボタンとスピナーの間隔を調整 */
   z-index: 1000; /* 他の要素よりも前面に表示 */
   opacity: 0;
+  visibility: hidden;
   transition: all 0.5s;
 }
 


### PR DESCRIPTION
Fixes #6