### PR TITLE
Improve button stacking order

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -22,7 +22,7 @@
   display: flex;
   flex-wrap: wrap;
   gap: 10px; /* ボタンとスピナーの間隔を調整 */
-  z-index: 1000; /* 他の要素よりも前面に表示 */
+  z-index: 10; /* ダイアログより前面に出ないよう調整 */
   opacity: 0;
   visibility: hidden;
   transition: all 0.5s;


### PR DESCRIPTION
## Summary
- lower `#listendltool_download_container` z-index so modals appear above the copy button

## Testing
- `npm test` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_686467e9dc1083229b0e34152153f3ff